### PR TITLE
Remove UI search Operation section and force to use limit results

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Running build will output all the static files to the `packages/jaeger-ui/build`
 
 ```
 yarn install
-yarn build
+GENERATE_SOURCEMAP=false yarn build
 ```
 
 ## UI Configuration

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.js
@@ -264,8 +264,9 @@ export class SearchFormImpl extends React.PureComponent {
       services,
       submitting: disabled,
     } = this.props;
-    const selectedServicePayload = services.find(s => s.name === selectedService);
-    const opsForSvc = (selectedServicePayload && selectedServicePayload.operations) || [];
+    // remove "operation" search item
+    // const selectedServicePayload = services.find(s => s.name === selectedService);
+    // const opsForSvc = (selectedServicePayload && selectedServicePayload.operations) || [];
     const noSelectedService = selectedService === '-' || !selectedService;
     const tz = selectedLookback === 'custom' ? new Date().toTimeString().replace(/^.*?GMT/, 'UTC') : null;
     return (
@@ -289,6 +290,7 @@ export class SearchFormImpl extends React.PureComponent {
             }}
           />
         </FormItem>
+        {/* remove" operation" search item
         <FormItem
           label={
             <span>
@@ -308,6 +310,7 @@ export class SearchFormImpl extends React.PureComponent {
             }}
           />
         </FormItem>
+        */}
 
         <FormItem
           label={
@@ -443,7 +446,9 @@ export class SearchFormImpl extends React.PureComponent {
             type="number"
             component={AdaptedInput}
             placeholder="Limit Results"
-            props={{ disabled, min: 1, max: 1500 }}
+            // force using of "Limit Results" in search
+            // props={{ disabled, min: 1, max: 1500 }}
+            props={{ required: true, min: 1, max: 2500 }}
           />
         </FormItem>
 

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.test.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.test.js
@@ -135,7 +135,7 @@ describe('conversion utils', () => {
 describe('lookback utils', () => {
   describe('lookbackToTimestamp', () => {
     const hourInMicroseconds = 60 * 60 * 1000 * 1000;
-    const now = new Date();
+    const now = moment.utc(new Date());
     const nowInMicroseconds = now * 1000;
 
     it('creates timestamp for hours ago', () => {
@@ -353,13 +353,14 @@ describe('<SearchForm>', () => {
     wrapper = shallow(<SearchForm {...defaultProps} />);
   });
 
-  it('enables operations only when a service is selected', () => {
-    let ops = wrapper.find('[placeholder="Select An Operation"]');
-    expect(ops.prop('props').disabled).toBe(true);
-    wrapper = shallow(<SearchForm {...defaultProps} selectedService="svcA" />);
-    ops = wrapper.find('[placeholder="Select An Operation"]');
-    expect(ops.prop('props').disabled).toBe(false);
-  });
+  // disable operations test due to remove from UI
+  // it('enables operations only when a service is selected', () => {
+  //  let ops = wrapper.find('[placeholder="Select An Operation"]');
+  //  expect(ops.prop('props').disabled).toBe(true);
+  //  wrapper = shallow(<SearchForm {...defaultProps} selectedService="svcA" />);
+  //  ops = wrapper.find('[placeholder="Select An Operation"]');
+  //  expect(ops.prop('props').disabled).toBe(false);
+  // });
 
   it('shows custom date inputs when `props.selectedLookback` is "custom"', () => {
     function getDateFieldLengths(compWrapper) {


### PR DESCRIPTION
## Which problem is this PR solving?
- UI search Operation section can have huge mount of data that can overload Jaeger-query service

## Short description of the changes
- Remove search Operation section from UI
- Force to use "Limit Results" which is set to default(20), min(1) and max(2500)
- Fix unit tests
